### PR TITLE
refactor(types): use default import if single object is exported

### DIFF
--- a/packages/plugin-component/src/component-plugin.ts
+++ b/packages/plugin-component/src/component-plugin.ts
@@ -1,4 +1,4 @@
-import type { PluginWithOptions } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import { createHtmlBlockRule } from './html-block-rule.js';
 import { htmlInlineRule } from './html-inline-rule.js';
 import type { ComponentPluginOptions } from './types.js';
@@ -6,10 +6,9 @@ import type { ComponentPluginOptions } from './types.js';
 /**
  * Allows better use of Vue components in Markdown
  */
-export const componentPlugin: PluginWithOptions<ComponentPluginOptions> = (
-  md,
-  { blockTags = [], inlineTags = [] } = {},
-): void => {
+export const componentPlugin: MarkdownIt.PluginWithOptions<
+  ComponentPluginOptions
+> = (md, { blockTags = [], inlineTags = [] } = {}): void => {
   const htmlBlockRule = createHtmlBlockRule({
     blockTags,
     inlineTags,

--- a/packages/plugin-component/src/html-block-rule.ts
+++ b/packages/plugin-component/src/html-block-rule.ts
@@ -1,4 +1,4 @@
-import type { RuleBlock } from 'markdown-it/lib/parser_block.js';
+import type ParserBlock from 'markdown-it/lib/parser_block.js';
 import {
   HTML_OPEN_AND_CLOSE_TAG_IN_THE_SAME_LINE_RE,
   HTML_OPEN_CLOSE_TAG_RE,
@@ -58,7 +58,7 @@ const createHtmlSequences = ({
 
 export const createHtmlBlockRule = (
   options: Required<ComponentPluginOptions>,
-): RuleBlock => {
+): ParserBlock.RuleBlock => {
   const HTML_SEQUENCES = createHtmlSequences(options);
 
   return (state, startLine, endLine, silent): boolean => {

--- a/packages/plugin-component/src/html-inline-rule.ts
+++ b/packages/plugin-component/src/html-inline-rule.ts
@@ -1,4 +1,4 @@
-import type { RuleInline } from 'markdown-it/lib/parser_inline.js';
+import type ParserInline from 'markdown-it/lib/parser_inline.js';
 import { HTML_TAG_RE } from './html-re.js';
 
 // Forked and modified from 'markdown-it/lib/rules_inline/html_inline.js'
@@ -8,7 +8,7 @@ const isLetter = (ch: number): boolean => {
   return lc >= 0x61 /* a */ && lc <= 0x7a; /* z */
 };
 
-export const htmlInlineRule: RuleInline = (state, silent) => {
+export const htmlInlineRule: ParserInline.RuleInline = (state, silent) => {
   const { pos } = state;
 
   if (!state.md.options.html) {

--- a/packages/plugin-frontmatter/src/frontmatter-plugin.ts
+++ b/packages/plugin-frontmatter/src/frontmatter-plugin.ts
@@ -1,6 +1,6 @@
 import type { MarkdownItEnv } from '@mdit-vue/types';
 import grayMatter from 'gray-matter';
-import type { PluginWithOptions } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import type { FrontmatterPluginOptions } from './types.js';
 
 /**
@@ -8,10 +8,9 @@ import type { FrontmatterPluginOptions } from './types.js';
  *
  * Extract them into env
  */
-export const frontmatterPlugin: PluginWithOptions<FrontmatterPluginOptions> = (
-  md,
-  { grayMatterOptions, renderExcerpt = true } = {},
-): void => {
+export const frontmatterPlugin: MarkdownIt.PluginWithOptions<
+  FrontmatterPluginOptions
+> = (md, { grayMatterOptions, renderExcerpt = true } = {}): void => {
   const render = md.render.bind(md);
   md.render = (src, env: MarkdownItEnv = {}) => {
     const { data, content, excerpt = '' } = grayMatter(src, grayMatterOptions);

--- a/packages/plugin-frontmatter/src/types.ts
+++ b/packages/plugin-frontmatter/src/types.ts
@@ -1,6 +1,6 @@
-import type { GrayMatterOption } from 'gray-matter';
+import type matter from 'gray-matter';
 
-type GrayMatterOptions = GrayMatterOption<string, GrayMatterOptions>;
+type GrayMatterOptions = matter.GrayMatterOption<string, GrayMatterOptions>;
 
 /**
  * Options of @mdit-vue/plugin-frontmatter

--- a/packages/plugin-headers/src/headers-plugin.ts
+++ b/packages/plugin-headers/src/headers-plugin.ts
@@ -3,7 +3,7 @@ import {
   resolveHeadersFromTokens,
 } from '@mdit-vue/shared';
 import type { MarkdownItEnv } from '@mdit-vue/types';
-import type { PluginWithOptions } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import type { HeadersPluginOptions } from './types.js';
 
 /**
@@ -11,10 +11,9 @@ import type { HeadersPluginOptions } from './types.js';
  *
  * Extract them into env
  */
-export const headersPlugin: PluginWithOptions<HeadersPluginOptions> = (
-  md,
-  { level = [2, 3], slugify = defaultSlugify, format } = {},
-): void => {
+export const headersPlugin: MarkdownIt.PluginWithOptions<
+  HeadersPluginOptions
+> = (md, { level = [2, 3], slugify = defaultSlugify, format } = {}): void => {
   // extract headers to env
   const render = md.renderer.render.bind(md.renderer);
   md.renderer.render = (tokens, options, env: MarkdownItEnv) => {

--- a/packages/plugin-sfc/src/sfc-plugin.ts
+++ b/packages/plugin-sfc/src/sfc-plugin.ts
@@ -1,5 +1,5 @@
 import type { MarkdownItEnv } from '@mdit-vue/types';
-import type { PluginWithOptions } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import {
   TAG_NAME_SCRIPT,
   TAG_NAME_STYLE,
@@ -14,7 +14,7 @@ import type { SfcPluginOptions } from './types.js';
  *
  * Extract them into env and avoid rendering them
  */
-export const sfcPlugin: PluginWithOptions<SfcPluginOptions> = (
+export const sfcPlugin: MarkdownIt.PluginWithOptions<SfcPluginOptions> = (
   md,
   { customBlocks = [] }: SfcPluginOptions = {},
 ): void => {

--- a/packages/plugin-title/src/title-plugin.ts
+++ b/packages/plugin-title/src/title-plugin.ts
@@ -1,13 +1,13 @@
 import { resolveTitleFromToken } from '@mdit-vue/shared';
 import type { MarkdownItEnv } from '@mdit-vue/types';
-import type { PluginSimple } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 
 /**
  * Get markdown page title info
  *
  * Extract it into env
  */
-export const titlePlugin: PluginSimple = (md): void => {
+export const titlePlugin: MarkdownIt.PluginSimple = (md): void => {
   // extract title to env
   const render = md.renderer.render.bind(md.renderer);
   md.renderer.render = (tokens, options, env: MarkdownItEnv) => {

--- a/packages/plugin-toc/src/create-toc-block-rule.ts
+++ b/packages/plugin-toc/src/create-toc-block-rule.ts
@@ -1,4 +1,4 @@
-import type { RuleBlock } from 'markdown-it/lib/parser_block.js';
+import type ParserBlock from 'markdown-it/lib/parser_block.js';
 import type { TocPluginOptions } from './types.js';
 
 /**
@@ -16,7 +16,7 @@ export const createTocBlockRule = ({
 }: Pick<
   Required<TocPluginOptions>,
   'pattern' | 'containerTag' | 'containerClass'
->): RuleBlock => {
+>): ParserBlock.RuleBlock => {
   return (state, startLine, endLine, silent): boolean => {
     // if it's indented more than 3 spaces, it should be a code block
     if (state.sCount[startLine] - state.blkIndent >= 4) {

--- a/packages/plugin-toc/src/toc-plugin.ts
+++ b/packages/plugin-toc/src/toc-plugin.ts
@@ -2,7 +2,7 @@ import {
   slugify as defaultSlugify,
   resolveHeadersFromTokens,
 } from '@mdit-vue/shared';
-import type { PluginWithOptions } from 'markdown-it';
+import type MarkdownIt from 'markdown-it';
 import { createRenderHeaders } from './create-render-headers.js';
 import { createTocBlockRule } from './create-toc-block-rule.js';
 import type { TocPluginOptions } from './types.js';
@@ -14,7 +14,7 @@ import type { TocPluginOptions } from './types.js';
  *
  * @see https://github.com/nagaozen/markdown-it-toc-done-right
  */
-export const tocPlugin: PluginWithOptions<TocPluginOptions> = (
+export const tocPlugin: MarkdownIt.PluginWithOptions<TocPluginOptions> = (
   md,
   {
     pattern = /^\[\[toc\]\]$/i,


### PR DESCRIPTION
`markdown-it` and `gray-matter` are using `export =` syntax.

Currently there is `import type { Foo } from 'bar'` like syntax, which is preventing `rollup-plugin-dts` to resolve those types (x-ref: https://github.com/vuejs/vitepress/issues/1254). This PR changes that to: `import type Bar from 'bar'` and `Bar.Foo` for type.