### PR TITLE
Remove duplicate itemClass

### DIFF
--- a/packages/plugin-toc/src/create-render-headers.ts
+++ b/packages/plugin-toc/src/create-render-headers.ts
@@ -28,7 +28,7 @@ export const createRenderHeaders = ({
 ${headers
   .map(
     (header) => `\
-<${itemTagString}${itemClassString}${itemClassString}>\
+<${itemTagString}${itemClassString}>\
 <${linkTagString}${linkClassString}${linkTo(header.link)}>\
 ${header.title}\
 </${linkTagString}>\


### PR DESCRIPTION
This leads to duplicate `class` attributes at the moment.